### PR TITLE
feat: http2

### DIFF
--- a/src/http2.js
+++ b/src/http2.js
@@ -94,8 +94,7 @@ class Http2Client {
     })
   }
 
-  async fetch ({
-    path: _path,
+  async fetch (_path, {
     headers = {},
     method = 'GET',
     body
@@ -150,7 +149,9 @@ class Http2Client {
         resolve({
           headers: responseHeaders,
           status: responseHeaders[HTTP2_HEADER_STATUS],
-          data: Buffer.concat(chunks)
+          ok: String(responseHeaders[HTTP2_HEADER_STATUS]).startsWith('2'),
+          data: Buffer.concat(chunks),
+          buffer: () => Buffer.concat(chunks)
         })
       }
 

--- a/src/http2.js
+++ b/src/http2.js
@@ -115,7 +115,7 @@ class Http2Client {
       await this._writeBody(request, body)
     }
 
-    return new Promise((resolve) => {
+    return new Promise((resolve, reject) => {
       const cleanUp = () => {
         request.removeListener('response', onResponse)
         request.removeListener('data', onData)
@@ -146,12 +146,13 @@ class Http2Client {
       const onEnd = () => {
         debug('request ended.')
         cleanUp()
+        const data = Buffer.concat(chunks)
         resolve({
           headers: responseHeaders,
           status: responseHeaders[HTTP2_HEADER_STATUS],
           ok: String(responseHeaders[HTTP2_HEADER_STATUS]).startsWith('2'),
-          data: Buffer.concat(chunks),
-          buffer: () => Buffer.concat(chunks)
+          buffer: () => data,
+          data
         })
       }
 
@@ -161,6 +162,12 @@ class Http2Client {
       request.once('end', onEnd)
       request.end()
     })
+  }
+
+  close () {
+    if (this._client) {
+      this._client.close()
+    }
   }
 }
 


### PR DESCRIPTION
Adds support for HTTP2 as a client. The assumption is still that the HTTP server is behind a load balancer or proxy, which would terminate HTTP2 if it is used by the peer.