### PR TITLE
Feat: add connection pool to http2 class

### DIFF
--- a/src/lib/http2.ts
+++ b/src/lib/http2.ts
@@ -93,7 +93,7 @@ export default class Http2Client {
   }: Http2FetchParams): Promise<Http2FetchResponse> {
     const path = _path || this._defaultPath
 
-    debug('creating request. path=', path, 'method=', method)
+    // debug('creating request. path=', path, 'method=', method)
     const request = client.request({
       [HTTP2_HEADER_PATH]: path,
       [HTTP2_HEADER_METHOD]: method,
@@ -102,16 +102,18 @@ export default class Http2Client {
 
     // write the body to the stream
     if (body) {
-      debug('writing body to request.')
+      // debug('writing body to request.')
       await this._writeBody(request, body)
     }
 
     return new Promise((resolve, reject) => {
       const cleanUp = () => {
-        request.removeListener('response', onResponse)
-        request.removeListener('data', onData)
-        request.removeListener('error', onError)
-        request.removeListener('end', onEnd)
+        setImmediate(() => {
+          request.removeListener('response', onResponse)
+          request.removeListener('data', onData)
+          request.removeListener('error', onError)
+          request.removeListener('end', onEnd)
+        })
       }
 
       const responseHeaders: Map<string, string> = new Map()

--- a/src/lib/http2.ts
+++ b/src/lib/http2.ts
@@ -99,7 +99,6 @@ export default class Http2Client {
   }: Http2FetchParams): Promise<Http2FetchResponse> {
     const path = _path || this._defaultPath
 
-    debug('creating request. path=', path, 'method=', method)
     const request = client.request({
       [HTTP2_HEADER_PATH]: path,
       [HTTP2_HEADER_METHOD]: method,
@@ -108,7 +107,6 @@ export default class Http2Client {
 
     // write the body to the stream
     if (body) {
-      debug('writing body to request.')
       await this._writeBody(request, body)
     }
 
@@ -124,7 +122,6 @@ export default class Http2Client {
 
       const responseHeaders: Map<string, string> = new Map()
       const onResponse = (headers: HeaderMap, flags: number) => {
-        debug('got response headers. status=', headers[HTTP2_HEADER_STATUS])
         for (const name in headers) {
           responseHeaders.set(name, headers[name])
         }
@@ -132,7 +129,6 @@ export default class Http2Client {
 
       const chunks: Array<Buffer> = []
       const onData = (chunk: Buffer) => {
-        debug('got chunk of data. length=', chunk.length)
         chunks.push(chunk)
       }
 

--- a/src/lib/http2.ts
+++ b/src/lib/http2.ts
@@ -54,8 +54,6 @@ export default class Http2Client {
         try {
           const result = await cb(client)
           return result
-        } catch (e) {
-          throw e
         } finally {
           session.freeRequest()
         }

--- a/src/lib/http2.ts
+++ b/src/lib/http2.ts
@@ -99,7 +99,7 @@ export default class Http2Client {
   }: Http2FetchParams): Promise<Http2FetchResponse> {
     const path = _path || this._defaultPath
 
-    // debug('creating request. path=', path, 'method=', method)
+    debug('creating request. path=', path, 'method=', method)
     const request = client.request({
       [HTTP2_HEADER_PATH]: path,
       [HTTP2_HEADER_METHOD]: method,
@@ -108,7 +108,7 @@ export default class Http2Client {
 
     // write the body to the stream
     if (body) {
-      // debug('writing body to request.')
+      debug('writing body to request.')
       await this._writeBody(request, body)
     }
 
@@ -124,7 +124,7 @@ export default class Http2Client {
 
       const responseHeaders: Map<string, string> = new Map()
       const onResponse = (headers: HeaderMap, flags: number) => {
-        // debug('got response headers. status=', headers[HTTP2_HEADER_STATUS])
+        debug('got response headers. status=', headers[HTTP2_HEADER_STATUS])
         for (const name in headers) {
           responseHeaders.set(name, headers[name])
         }
@@ -132,15 +132,11 @@ export default class Http2Client {
 
       const chunks: Array<Buffer> = []
       const onData = (chunk: Buffer) => {
-        // debug('got chunk of data. length=', chunk.length)
+        debug('got chunk of data. length=', chunk.length)
         chunks.push(chunk)
       }
 
       const onError = (error: Error) => {
-        if (client.remoteSettings.maxConcurrentStreams !== 256) {
-          console.log('error, logging remote settings', client.remoteSettings)
-        }
-
         debug('got request error. error=', error.message)
         cleanUp()
         reject(error)

--- a/src/lib/http2.ts
+++ b/src/lib/http2.ts
@@ -31,7 +31,7 @@ export interface Http2FetchResponse {
 export default class Http2Client {
   private _url: URL
   private _authority: string
-  private _http2Opts: string
+  private _http2Opts: object
   private _defaultPath: string
   private _sessions: Array<Http2Session>
 
@@ -44,7 +44,7 @@ export default class Http2Client {
     this._sessions = []
   }
 
-  async _allocateRequestAndRun<T>(cb: (client: http2.Http2Client) => Promise<T>): Promise<T> {
+  async _allocateRequestAndRun<T>(cb: (client: http2.ClientHttp2Session) => Promise<T>): Promise<T> {
     for (const session of this._sessions) {
       const client = await session.allocateRequest()
 

--- a/src/lib/http2Session.ts
+++ b/src/lib/http2Session.ts
@@ -1,0 +1,94 @@
+import * as makeDebug from 'debug'
+import * as http2 from 'http2'
+
+const debug = makeDebug('http2session')
+
+enum ConnectState {
+  DISCONNECTED,
+  CONNECTING,
+  CONNECTED
+}
+
+export default class Http2Session {
+  private _authority: string
+  private _http2Opts: object
+  private _requests: number
+
+  private _connected: ConnectState
+  private _connectPromise: Promise<http2.ClientHttp2Session>
+  private _client: http2.ClientHttp2Session
+
+  constructor (authority, http2Opts) {
+    this._authority = authority
+    this._http2Opts = http2Opts
+    this._connected = ConnectState.DISCONNECTED
+    this._requests = 0
+  }
+
+  async allocateRequest (): Promise<http2.ClientHttp2Session | undefined> {
+    const client = await this.connect()
+    if (this._requests >= client.remoteSettings.maxConcurrentStreams) {
+      return
+    } else {
+      this._requests++
+      return client
+    }
+  }
+
+  freeRequest (): void {
+    this._requests--
+  }
+
+  _connect () {
+    if (this._connected === ConnectState.CONNECTED && this._client) {
+      return Promise.resolve(this._client)
+    } else if (this._connected === ConnectState.CONNECTING && this._connectPromise) {
+      return this._connectPromise
+    }
+
+    debug('creating client. authority=', this._authority)
+    const client = http2.connect(this._authority, this._http2Opts)
+
+    this._client = client
+    this._connected = ConnectState.CONNECTING
+    this._connectPromise = new Promise((resolve, reject) => {
+      const cleanUp = () => {
+        client.removeListener('connect', onConnect)
+        client.removeListener('error', onError)
+        client.removeListener('close', onClose)
+      }
+
+      const onConnect = () => {
+        debug('client connected.')
+        client.removeListener('connect', onConnect)
+        this._connected = ConnectState.CONNECTED
+        resolve(client)
+      }
+
+      const onClose = () => {
+        debug('client closed.')
+        cleanUp()
+        this._connected = ConnectState.DISCONNECTED
+        reject(new Error('closed while opening connection'))
+      }
+
+      // TODO: log the error
+      const onError = (error: Error) => {
+        debug('client encountered error. error=', error.message)
+        cleanUp()
+        this._connected = ConnectState.DISCONNECTED
+        reject(error)
+      }
+
+      client.on('connect', onConnect)
+      client.on('close', onClose)
+      client.on('error', onError)
+    })
+  }
+
+  close () {
+    if (this._client) {
+      this._client.close()
+    }
+  }
+}

--- a/src/lib/http2Session.ts
+++ b/src/lib/http2Session.ts
@@ -57,9 +57,11 @@ export default class Http2Session {
     this._connected = ConnectState.CONNECTING
     this._connectPromise = new Promise((resolve, reject) => {
       const cleanUp = () => {
-        client.removeListener('connect', onConnect)
-        client.removeListener('error', onError)
-        client.removeListener('close', onClose)
+        setImmediate(() => {
+          client.removeListener('connect', onConnect)
+          client.removeListener('error', onError)
+          client.removeListener('close', onClose)
+        })
       }
 
       const onConnect = () => {

--- a/src/lib/http2Session.ts
+++ b/src/lib/http2Session.ts
@@ -3,6 +3,7 @@ import * as http2 from 'http2'
 
 const debug = makeDebug('http2session')
 const DEFAULT_MAX_STREAMS = (2 ** 31) - 1
+const MAX_TOTAL_REQUESTS = Infinity
 
 enum ConnectState {
   DISCONNECTED,
@@ -14,16 +15,23 @@ export default class Http2Session {
   private _authority: string
   private _http2Opts: object
   private _requests: number
+  private _totalRequests: number
+  private _maxRequests: number
 
   private _connected: ConnectState
   private _connectPromise: Promise<http2.ClientHttp2Session>
   private _client: http2.ClientHttp2Session
 
-  constructor (authority: string, http2Opts: object) {
+  public id: string
+
+  constructor (authority: string, http2Opts: object, maxRequests?: number) {
+    this.id = String(Math.random()).substring(2)
     this._authority = authority
     this._http2Opts = http2Opts
     this._connected = ConnectState.DISCONNECTED
     this._requests = 0
+    this._totalRequests = 0
+    this._maxRequests = maxRequests || MAX_TOTAL_REQUESTS
   }
 
   async allocateRequest (): Promise<http2.ClientHttp2Session | undefined> {
@@ -31,10 +39,11 @@ export default class Http2Session {
     const maxStreams = client.remoteSettings.maxConcurrentStreams ||
       DEFAULT_MAX_STREAMS
 
-    if (this._requests >= maxStreams) {
+    if (this._requests >= maxStreams || this._totalRequests >= this._maxRequests) {
       return
     } else {
       this._requests++
+      this._totalRequests++
       return client
     }
   }
@@ -44,7 +53,9 @@ export default class Http2Session {
   }
 
   _connect (): Promise<http2.ClientHttp2Session> {
-    if (this._connected === ConnectState.CONNECTED && this._client) {
+    if (this._requests === 0 && this._totalRequests >= this._maxRequests) {
+      debug('hit maximum requests; resetting connection')
+    } else if (this._connected === ConnectState.CONNECTED && this._client) {
       return Promise.resolve(this._client)
     } else if (this._connected === ConnectState.CONNECTING && this._connectPromise) {
       return this._connectPromise
@@ -53,6 +64,7 @@ export default class Http2Session {
     debug('creating client. authority=', this._authority)
     const client = http2.connect(this._authority, this._http2Opts)
 
+    this._totalRequests = 0
     this._client = client
     this._connected = ConnectState.CONNECTING
     this._connectPromise = new Promise((resolve, reject) => {

--- a/test/testHttp2.js
+++ b/test/testHttp2.js
@@ -2,7 +2,9 @@ const Http2Client = require('../build/lib/http2').default
 
 async function run () {
   console.log('making client')
-  const client = new Http2Client('https://staging.coil.com')
+  const client = new Http2Client('https://staging.coil.com', {
+    maxRequestsPerSession: 900
+  })
 
   console.log('fetching site 5k times')
   let result
@@ -10,7 +12,7 @@ async function run () {
   let successes = 0
   let failures = 0
 
-  for (let i = 0; i < 10; ++i) {
+  for (let i = 0; i < 15; ++i) {
     console.log('iteration', i)
     result = await Promise.all([ ...Array(5000).keys() ].map(async () => {
       try {

--- a/test/testHttp2.js
+++ b/test/testHttp2.js
@@ -2,14 +2,30 @@ const Http2Client = require('../build/lib/http2').default
 
 async function run () {
   console.log('making client')
-  const client = new Http2Client('https://coil.com')
+  const client = new Http2Client('https://staging.coil.com')
 
   console.log('fetching site 5k times')
-  const result = await Promise.all([ ...Array(5000).keys() ].map(() => {
-    return client.fetch('/', {})
-  }))
+  let result
+
+  let successes = 0
+  let failures = 0
+
+  for (let i = 0; i < 10; ++i) {
+    console.log('iteration', i)
+    result = await Promise.all([ ...Array(5000).keys() ].map(async () => {
+      try {
+        const result = await client.fetch('/', {})
+        successes++
+        return result
+      } catch (e) {
+        failures++
+      }
+    }))
+  }
 
   console.log('fetched.')
+  console.log('success:', successes)
+  console.log('failure:', failures)
   console.log(result[0])
   console.log(result[0].buffer().toString())
 }

--- a/test/testHttp2.js
+++ b/test/testHttp2.js
@@ -4,11 +4,14 @@ async function run () {
   console.log('making client')
   const client = new Http2Client('https://coil.com')
 
-  console.log('fetching site')
-  const result = await client.fetch('/', {})
+  console.log('fetching site 5k times')
+  const result = await Promise.all([ ...Array(5000).keys() ].map(() => {
+    return client.fetch('/', {})
+  }))
 
-  console.log(result)
-  console.log(result.buffer().toString())
+  console.log('fetched.')
+  console.log(result[0])
+  console.log(result[0].buffer().toString())
 }
 
 run()


### PR DESCRIPTION
In the current version of plugin-http, the HTTP2 Client represents a single connection to an origin. Many requests can be sent over this single connection.

We ran into a problem where an HTTP2 server limits the number of open requests on a single connection. The HTTP2 client didn't look at this limit, so it would send requests as much as it wanted and then the connection would get severed when it exceeded the max requests in flight.

So we were basically faced with two options to deal with this requests-in-flight limit:

1. When MAX_REQUESTS are in flight, start queueing new requests that we want to send.
2. When MAX_REQUESTS are in flight, create a new connection and put the new requests over that.

I decided to go with 2, basically creating a connection pool that lets us have as many requests in flight as we want by spreading them across multiple connections.

EDIT: still seeing the NGHTTP2_REFUSED_STREAM error once every ~20k requests (doing 5k requests concurrently, so 50 connections open). Looking into it but I suspect it's something to do with the freeing logic, and the request not always being 100% done when that happens.

EDIT: looks like the reason that the NGHTTP2_REFUSED_STREAM thing was crashing the process was because it emits an `end` AND and `error`. The `end` was emitted first, and the listener for `error` was removed. It now waits a tick before unbinding the `error` listener. However, it's still causing an NGHTTP2_REFUSED_STREAM which shouldn't be happening.

EDIT: it looks like some servers have a (secret) limit on how many requests you can put over a single connection (not concurrent requests, but requests total). It looks like cloudflare puts this at 1000. The one strange thing is that I get NGHTTP2_REFUSED_STREAM when testing the actual plugin and when I try to replicate >1000 requests I get ERR_HTTP2_INVALID_SESSION. However, I found in my logs that all sessions exceeding 1000 requests die due to an error.

EDIT: added a limit on max requests per session. This isn't an official parameter of HTTP2 so it needs to be passed in manually under `outgoing.http2MaxRequestsPerSession`. The default is still infinite but it should be set to `999` against cloudflare. Cloudflare closes the connection on request `1000`. Some servers may not have this limit at all. On testing 75k requests with 5k in flight at a time, this gives 75k successes and 0 failed requests.