### PR TITLE
feat: optional custom delimiter for multi mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ For an example of usage, see the test script in `test/test.js`.
 ```js
 new PluginHttp({
   multi: true, // whether to behave as a multilateral plugin
+  multiDelimiter: '^', // to specifiy a delimiter other than default `%`
   ildcp: { // ildcp details. fetched if multilateral and unspecified.
     clientAddress: 'test.example',
     assetCode: 'XRP',

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,6 +20,7 @@ const INVALID_SEGMENT = new RegExp('[^A-Za-z0-9_\\-]')
 
 export interface PluginHttpOpts {
   multi?: boolean
+  multiDelimiter?: string
   ildcp?: ILDCP.IldcpResponse
 
   incoming: {
@@ -49,6 +50,7 @@ type PacketHandler = (data: Buffer) => Promise<Buffer>
 class PluginHttp extends EventEmitter {
   private _connected: boolean
   private _multi: boolean
+  private _multiDelimiter: string
   private _ildcp?: ILDCP.IldcpResponse
   private _port: number
   private _url: string
@@ -64,12 +66,13 @@ class PluginHttp extends EventEmitter {
   private _app: Koa
   public static version: number
 
-  constructor ({ multi, ildcp, incoming, outgoing }: PluginHttpOpts) {
+  constructor ({ multi, multiDelimiter, ildcp, incoming, outgoing }: PluginHttpOpts) {
     super()
 
     // TODO: validate args
     this._connected = false
     this._multi = !!multi
+    this._multiDelimiter = multiDelimiter || '%' 
     this._ildcp = ildcp
 
     // incoming
@@ -190,7 +193,7 @@ class PluginHttp extends EventEmitter {
     }
 
     // splice the address segment into the URL
-    return this._url.replace('%', segment)
+    return this._url.replace(this._multiDelimiter, segment)
   }
 
   _getHttp2ClientForOrigin (origin: string): Http2Client {

--- a/test/test.js
+++ b/test/test.js
@@ -61,13 +61,14 @@ async function run () {
         },
         options: {
           multi: true,
+          multiDelimiter: '^',
           incoming: {
             secret: 'secret_number_three',
             port: port3
           },
           outgoing: {
             secretToken: 'secret_number_four',
-            url: 'http://localhost:%'
+            url: 'http://localhost:^'
           }
         }
       }


### PR DESCRIPTION
The `%` might not work under certain circumstances (e.g. if you are passing the config through a templating engine that does not support `%` as a regular character).