### PR TITLE
Separate HTTP basic auth from JWT auth in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ new PluginHttp({
   },
   incoming: { // (required) describes the http server
     port: 4000, // (required) port to listen on
-    secret: 'shhh', // secret for JWT auth (see Protocol section)
+    // secret: 'shhh', // secret for JWT auth (see Protocol section)
     secretToken: 'shhh' // (required) secret for auth (see Protocol section)
   },
   outgoing: { // (required) describes outgoing http calls
@@ -35,7 +35,7 @@ new PluginHttp({
     // segment after this plugin's own address will be filled where the `%` is
     // when routing packets.
 
-    secret: 'othersecret', // secret for JWT auth (see Protocol section)
+    // secret: 'othersecret', // secret for JWT auth (see Protocol section)
     secretToken: 'othersecret', // (required) secret for auth (see Protocol section)
     http2: false, // whether `url` uses http2
     tokenExpiry: 10 * 1000, // how often to sign a new token for auth

--- a/README.md
+++ b/README.md
@@ -26,7 +26,8 @@ new PluginHttp({
   },
   incoming: { // (required) describes the http server
     port: 4000, // (required) port to listen on
-    secret: 'shhh' // (required) secret for auth (see Protocol section)
+    secret: 'shhh', // secret for JWT auth (see Protocol section)
+    secretToken: 'shhh' // (required) secret for auth (see Protocol section)
   },
   outgoing: { // (required) describes outgoing http calls
     url: 'https://example.com/ilp/%', // (required) endpoint to POST packets to
@@ -34,7 +35,8 @@ new PluginHttp({
     // segment after this plugin's own address will be filled where the `%` is
     // when routing packets.
 
-    secret: 'othersecret', // (required) secret for auth (see Protocol section)
+    secret: 'othersecret', // secret for JWT auth (see Protocol section)
+    secretToken: 'othersecret', // (required) secret for auth (see Protocol section)
     http2: false, // whether `url` uses http2
     tokenExpiry: 10 * 1000, // how often to sign a new token for auth
     name: 'alice' // name to send in `ILP-Peer-Name` header, for ilp addr.


### PR DESCRIPTION
While creating a peering with Xpring, I adapted the example configuration from the README. This example however uses JWT and not HTTP basic auth as I thought. Can we change the README a little bit such that this difference becomes more obvious?