### PR TITLE
fix: update content-type to match ilp http spec

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -249,7 +249,7 @@ class PluginHttp extends EventEmitter {
 
     const headers = {
       Authorization: await this._getAuthHeader(),
-      'Content-Type': 'application/ilp+octet-stream',
+      'Content-Type': 'application/octet-stream',
       'ILP-Peer-Name': this._name
     }
 


### PR DESCRIPTION
When attempting to connect the JS connector to the Java connector, this became an issue as it does not match the content type outlined here: https://interledger.org/rfcs/0035-ilp-over-http/